### PR TITLE
Ensure P2P initial sync waits for channel open

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -77,11 +77,18 @@ function initP2P(){
     p2p.on("peerconnect", peer=>{
       peers.set(peer.id,{});
       setStatusChip();
-      try{
-        p2p.send(peer,`HELLO:${myName}`);
-        p2p.send(peer,`ROSTER:${JSON.stringify([myName, ...namesSeen])}`);
-        p2p.send(peer,"U:"+u8ToB64(Y.encodeStateAsUpdate(ydoc))); // one-shot full sync
-      }catch{}
+
+      // Send initial sync data once the data channel is confirmed open.
+      const sendInitial = ()=>{
+        try{
+          p2p.send(peer,`HELLO:${myName}`);
+          p2p.send(peer,`ROSTER:${JSON.stringify([myName, ...namesSeen])}`);
+          p2p.send(peer,"U:"+u8ToB64(Y.encodeStateAsUpdate(ydoc))); // one-shot full sync
+        }catch{}
+      };
+
+      if(peer.connected) sendInitial();
+      else peer.once("connect", sendInitial);
     });
 
     p2p.on("peerclose", peer=>{ peers.delete(peer.id); setStatusChip(); });


### PR DESCRIPTION
## Summary
- Only send initial HELLO, roster, and document state after the peer's data channel is confirmed connected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5600fd4048331804b55458d3ac549